### PR TITLE
Added information about Handla Group

### DIFF
--- a/Pro_Iran_md
+++ b/Pro_Iran_md
@@ -2,3 +2,4 @@
 | ------ | ------ | ------ | ------ |
 |DieNet|https://t.me/DIeNlt||https://dienet-cc.github.io/public_html - https://diedetector.ct.ws - Contact: @dnsupportbot|
 |DieNet (backup channel)|https://t.me/dienet2|||
+| Handala | (https://t.me/handala_hack26), (https://t.me/handala_channel) | (https://handala.to), (http://handala-hack.to), [.onion](http://vmjfieomxhnfjba57sd6jjws2ogvowjgxhhfglsikqvvrnrajbmpxqqd.onion) | Claimed breaches: Agura B.C LTD, Mor-logistics, Weizmann Institute of Science, TBN Israel, Israel’s fuel supply system, Data099 ISP, G. New Idan |


### PR DESCRIPTION
This PR adds pro-Iran cyber threat actor groups to the `ProIran' file:

- **Handala**: Includes Telegram, clearnet and .onion websites, and a list of claimed breaches after June 12