### PR TITLE
Added information about WeRedEvilsOG

### DIFF
--- a/Pro_Israel.md
+++ b/Pro_Israel.md
@@ -5,3 +5,4 @@
 |Garuna Ops|https://t.me/garunaops|||
 |Garuna Ops|https://t.me/+XhceuAZW9QJkOWJl|||
 |Predatory Sparrow|https://t.me/PredatorySparrowIL|||
+|RedEvilSog group|https://t.me/weredevilssupport,https://t.me/weredevilsog||X account https://x.com/redevilsog|

--- a/Pro_Israel.md
+++ b/Pro_Israel.md
@@ -5,4 +5,4 @@
 |Garuna Ops|https://t.me/garunaops|||
 |Garuna Ops|https://t.me/+XhceuAZW9QJkOWJl|||
 |Predatory Sparrow|https://t.me/PredatorySparrowIL|||
-|RedEvilSog group|https://t.me/weredevilssupport,https://t.me/weredevilsog||X account https://x.com/redevilsog|
+|RedEvilSog group|https://t.me/weredevilssupport,https://t.me/weredevilsog||X account https://x.com/redevilsog|||


### PR DESCRIPTION
This PR adds pro-Israel cyber threat actor groups to the `ProIsrael' file:

- WeRedEvilsOG: Includes Telegram, and their X account id
- Recently claimed responsibility for for hacking Iranian TV broadcasts 
- Source: https://x.com/Osint613/status/1935408245406933142 & https://x.com/redevilsog/status/1935403572503658868