### PR TITLE
Added information about Night Hunters

### DIFF
--- a/Pro_Iran.md
+++ b/Pro_Iran.md
@@ -47,7 +47,6 @@
 |Cyberjund|***enter the Telegram channel link here***|||
 |Fad Team|***enter the Telegram channel link here***|||
 |R-9X|***enter the Telegram channel link here***|||
-|Serverkillers|***enter the Telegram channel link here***|||
 |Legion|***enter the Telegram channel link here***|||
 |Assasins ZXR|***enter the Telegram channel link here***|||
 |Spider X|***enter the Telegram channel link here***|||

--- a/Pro_Israel.md
+++ b/Pro_Israel.md
@@ -8,6 +8,6 @@
 |RedEvilSog group|https://t.me/weredevilssupport,https://t.me/weredevilsog||X account https://x.com/redevilsog|||
 |Eagle7|***enter the Telegram channel link here***|||
 |NPFN|***enter the Telegram channel link here***|||
-|Night Hunters|***enter the Telegram channel link here***|||
+|Night Hunters|https://t.me/thenighthunterschat,https://t.me/+__nZCYRY1t02OGM1,https://t.me/+vbpFOVZzsAQ3NWQ1|||
 |Unkn0wn Gunm3n|***enter the Telegram channel link here***|||
 |Kaon|***enter the Telegram channel link here***|||


### PR DESCRIPTION
This PR adds pro-Israel cyber threat actor group Night Hunter's telegram link to the `Pro Israel' file.